### PR TITLE
Add realtime private events

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,51 @@ p private_client.positions # will print your positions
 
 ### Realtime API
 
+#### Public events
+
 Accessor format is like `{event_name}_{product_code}`.
 You can set lambda to get realtime events.
 
 `{event_name}` and `{product_code}` is defined at [client.rb](./lib/bitflyer/realtime/client.rb).
 
-#### Example
+#### Private events
 
+To subscribe to the private `child_order_events` and `parent_order_events`, pass your API key and secret when creating the `realtime_client`.
+
+#### Connection status monitoring
+
+The `ready` callback is called when the `realtime_client` is ready to receive events (after the socket connection is established, the optional authentication has succeeded, and the channels have been subscribed). If connection is lost, the `disconnected` callback is called, and reconnection is attempted automatically. When connection is restored, `ready` is called again.
+
+#### Examples
+
+For public events only:
 ```ruby
 client = Bitflyer.realtime_client
-client.ticker_btc_jpy = ->(json){ p json } # will print json object 
+client.ticker_btc_jpy = ->(json){ p json } # will print json object
 client.executions_btc_jpy = ->(json){ p json }
-# ... 
+# ...
 ```
+
+For both public and private events:
+```ruby
+client = Bitflyer.realtime_client('YOUR_API_KEY', 'YOUR_API_SECRET')
+# Private events:
+client.child_order_events = ->(json){ p json }
+client.parent_order_events = ->(json){ p json }
+# Public events:
+client.ticker_btc_jpy = ->(json){ p json }
+client.executions_btc_jpy = ->(json){ p json }
+# ...
+```
+
+Connection monitoring:
+```ruby
+client = Bitflyer.realtime_client
+client.ready = -> { p "Client is ready to receive events" }
+client.disconnected = ->(error) { p "Client got disconnected" }
+```
+
+
 
 ## Contributing
 

--- a/lib/bitflyer.rb
+++ b/lib/bitflyer.rb
@@ -5,8 +5,8 @@ require 'bitflyer/http'
 require 'bitflyer/realtime'
 
 module Bitflyer
-  def realtime_client
-    Bitflyer::Realtime::Client.new
+  def realtime_client(key = nil, secret = nil)
+    Bitflyer::Realtime::Client.new(key, secret)
   end
 
   def http_public_client

--- a/lib/bitflyer/realtime/client.rb
+++ b/lib/bitflyer/realtime/client.rb
@@ -13,6 +13,8 @@ module Bitflyer
     SOCKET_HOST = 'https://io.lightstream.bitflyer.com'
 
     class Client
+      extend Forwardable
+      def_delegators :@websocket_client, :ready=, :disconnected=
       attr_accessor :websocket_client, :ping_interval, :ping_timeout, :last_ping_at, :last_pong_at
 
       Realtime::CHANNEL_NAMES.each do |channel_name|

--- a/lib/bitflyer/realtime/client.rb
+++ b/lib/bitflyer/realtime/client.rb
@@ -4,9 +4,11 @@ require_relative './websocket'
 
 module Bitflyer
   module Realtime
-    EVENT_NAMES = %w[lightning_board_snapshot lightning_board lightning_ticker lightning_executions].freeze
+    PUBLIC_EVENT_NAMES = %w[lightning_board_snapshot lightning_board lightning_ticker lightning_executions].freeze
     MARKETS = %w[BTC_JPY FX_BTC_JPY ETH_BTC BCH_BTC BTCJPY_MAT3M BTCJPY_MAT1WK BTCJPY_MAT2WK].freeze
-    CHANNEL_NAMES = EVENT_NAMES.product(MARKETS).map { |e, m| "#{e}_#{m}" }
+    PUBLIC_CHANNEL_NAMES = PUBLIC_EVENT_NAMES.product(MARKETS).map { |e, m| "#{e}_#{m}" }.freeze
+    PRIVATE_CHANNEL_NAMES = %w[child_order_events parent_order_events].freeze
+    CHANNEL_NAMES = (PUBLIC_CHANNEL_NAMES + PRIVATE_CHANNEL_NAMES).freeze
 
     SOCKET_HOST = 'https://io.lightstream.bitflyer.com'
 
@@ -19,8 +21,8 @@ module Bitflyer
         end
       end
 
-      def initialize
-        @websocket_client = Bitflyer::Realtime::WebSocketClient.new(host: SOCKET_HOST)
+      def initialize(key = nil, secret = nil)
+        @websocket_client = Bitflyer::Realtime::WebSocketClient.new(host: SOCKET_HOST, key: key, secret: secret)
       end
     end
   end

--- a/lib/bitflyer/realtime/websocket.rb
+++ b/lib/bitflyer/realtime/websocket.rb
@@ -6,7 +6,7 @@ require 'json'
 module Bitflyer
   module Realtime
     class WebSocketClient
-      attr_accessor :websocket_client, :channel_name, :channel_callbacks, :ping_interval, :ping_timeout,
+      attr_accessor :websocket_client, :channel_names, :channel_callbacks, :ping_interval, :ping_timeout,
                     :last_ping_at, :last_pong_at, :error
 
       def initialize(host:, debug: false)

--- a/lib/bitflyer/realtime/websocket.rb
+++ b/lib/bitflyer/realtime/websocket.rb
@@ -25,7 +25,7 @@ module Bitflyer
         debug_log "Subscribe #{channel_name}"
         @channel_names = (@channel_names + [channel_name]).uniq
         @channel_callbacks[channel_name] = block
-        websocket_client.send "42#{['subscribe', channel_name].to_json}"
+        @websocket_client.send "42#{['subscribe', channel_name].to_json}"
       end
 
       def connect
@@ -135,7 +135,7 @@ module Bitflyer
           nonce: nonce,
           signature: signature
         }
-        websocket_client.send "420#{['auth', auth_params].to_json}"
+        @websocket_client.send "420#{['auth', auth_params].to_json}"
       end
 
       def authenticated(json:)
@@ -149,9 +149,9 @@ module Bitflyer
       end
 
       def subscribe_channels
-        channel_callbacks.each do |channel_name, _|
+        @channel_callbacks.each do |channel_name, _|
           debug_log "42#{{ subscribe: channel_name }.to_json}"
-          websocket_client.send "42#{['subscribe', channel_name].to_json}"
+          @websocket_client.send "42#{['subscribe', channel_name].to_json}"
         end
       end
 
@@ -162,7 +162,7 @@ module Bitflyer
 
       def disconnect
         debug_log 'Disconnecting from server...'
-        websocket_client.close
+        @websocket_client.close
       end
 
       def emit_message(json:)

--- a/lib/bitflyer/realtime/websocket.rb
+++ b/lib/bitflyer/realtime/websocket.rb
@@ -80,10 +80,6 @@ module Bitflyer
 
         @websocket_client.close if @websocket_client.open?
         connect
-        @channel_names.each do |channel_name|
-          debug_log "42#{{ subscribe: channel_name }.to_json}"
-          websocket_client.send "42#{['subscribe', channel_name].to_json}"
-        end
       end
 
       def handle_error(error:)

--- a/lib/bitflyer/realtime/websocket.rb
+++ b/lib/bitflyer/realtime/websocket.rb
@@ -31,6 +31,9 @@ module Bitflyer
         this = self
         @websocket_client.on(:message) { |payload| this.handle_message(payload: payload) }
         @websocket_client.on(:error) { |error| this.handle_error(error: error) }
+      rescue SocketError => e
+        puts e
+        puts e.backtrace.join("\n")
       end
 
       def start_monitoring

--- a/lib/bitflyer/realtime/websocket.rb
+++ b/lib/bitflyer/realtime/websocket.rb
@@ -42,16 +42,9 @@ module Bitflyer
             if @websocket_client&.open?
               send_ping
               wait_pong
+            else
+              reconnect
             end
-          end
-        end
-
-        Thread.new do
-          loop do
-            sleep 1
-            next if @websocket_client&.open?
-
-            reconnect
           end
         end
       end


### PR DESCRIPTION
Thank you for a very clean code @unhappychoice,  it made it very easy to contribute!

Resolves #37
Resolves #169

TODOs:

- [x] Add private events
- [x] Update README
- [x] Improve reconnect behavior
- [x] Provide ready / disconnected callbacks (*)
- [x] Code review by @unhappychoice 

 *: If users are going to rely on the private events to track order executions, they need to know when the socket was disconnected and reconnected, so they get the executions they have missed using the HTTP client.